### PR TITLE
ci: add integration tests as realease dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
   deploy_test:
     name: Deploy for Testing
     runs-on: ubuntu-latest
-    needs: [lint, test, build]
+    needs: [lint, test, build, integration_test]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v4
@@ -124,6 +124,10 @@ jobs:
           echo "SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN_PROD }}" >> .env
           echo "SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET_PROD }}" >> .env
           echo "DEFAULT_FUNCTIONS_LOCATION=${{ secrets.DEFAULT_FUNCTIONS_LOCATION }}" >> .env
+
+      - name: Install Dependencies
+        working-directory: functions
+        run: npm ci
 
       - name: Build Functions
         working-directory: functions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment now waits for integration tests to complete before proceeding.
  * Dependencies are now installed in the functions directory before building during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->